### PR TITLE
Fix nyc code coverage script

### DIFF
--- a/test/aggregate-signal.ts
+++ b/test/aggregate-signal.ts
@@ -1,3 +1,4 @@
+/// <reference types='node' />
 import 'mocha';
 import chai, { expect } from 'chai';
 import spies from 'chai-spies';


### PR DESCRIPTION
An issue seems to have popped up where `ts-node` has issues with `AbortController` unless a reference to `node` is added.