### PR TITLE
Add simple C#-style `tryX` wrappers around `Procedure.call` and `Procedure.ping` as helpful utility methods

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,97 +1,179 @@
+/** Codes for determining the cause of errors encountered while working with procedures. */
 export enum ProcedureErrorCodes {
+    // 0 - 99: Reserved for exceptions of unknown origin.
+    /** An unhandled exception of unknown origin was thrown while handling the request. */
     UNKNOWN_ERROR = 0,
+
+    // 100 - 199: Reserved for exceptions originating from the client.
+    /** An unhandled exception was thrown while attempting to call the procedure. */
     INTERNAL_CLIENT_ERROR = 100,
+    /** The procedure could not be found at the stated endpoint. */
     NOT_FOUND = 101,
+    /** The operation was cancelled by the client. */
     CANCELLED = 102,
+    /** Timed out waiting for the operation to complete. */
     TIMED_OUT = 103,
+    /** The response from the server was invalid. */
     INVALID_RESPONSE = 104,
+
+    // 200 - 299: Reserved for exceptions originating from the server.
+    /** An unhandled exception was thrown while attempting to handle the procedure. */
     INTERNAL_SERVER_ERROR = 200,
+    /** An unhandled exception was thrown during procedure execution. */
     EXECUTION_ERROR = 201
 }
 
-export interface ProcedureError extends Error {
-    name: string;
-    code: ProcedureErrorCodes;
-    message: string;
+/** 
+ * Defines the interface of errors relating to procedures.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
+ */
+export abstract class ProcedureError implements Error {
+    /** The name of the error type. */
+    abstract name: string;
+    /** The code used to identify the error type. */
+    abstract code: ProcedureErrorCodes;
+    /** A message indicating the cause of the error. */
+    abstract message: string;
+    /** An optional dictionary of data which will be passed to a procedure's caller when thrown. */
     data?: Record<string, unknown>;
+
+    /**
+     * Initializes a new instance of {@link ProcedureError}
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+    constructor(data?: Record<string, unknown>) {
+        if (data) {
+            this.data = data;
+        }
+    }
 }
 
-export class ProcedureUnknownError implements ProcedureError {
+/** When thrown, indicates that an unhandled exception of unknown origin was thrown while handling the request. */
+export class ProcedureUnknownError extends ProcedureError {
     name = 'ProcedureUnknownError';
     code = ProcedureErrorCodes.UNKNOWN_ERROR;
-    message = 'An unhandled exception of unknown origin was thrown while handling the request';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'An unhandled exception of unknown origin was thrown while handling the request.';
+    /**
+     * Initializes an instance of {@link ProcedureUnknownError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+    constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureInternalClientError implements ProcedureError {
+/** When thrown, indicates that an unhandled exception was thrown while attempting to call the procedure. */
+export class ProcedureInternalClientError extends ProcedureError {
     name = 'ProcedureInternalClientError';
     code = ProcedureErrorCodes.INTERNAL_CLIENT_ERROR;
-    message = 'An internal exception was thrown';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'An unhandled exception was thrown while attempting to call the procedure.';
+    /**
+     * Initializes an instance of {@link ProcedureInternalClientError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureNotFoundError implements ProcedureError {
+/** When thrown, indicates that the procedure could not be found at the stated endpoint. */
+export class ProcedureNotFoundError extends ProcedureError {
     name = 'ProcedureNotFoundError';
     code = ProcedureErrorCodes.NOT_FOUND;
-    message = 'The procedure could not be found at the endpoint';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'The procedure could not be found at the stated endpoint.';
+    /**
+     * Initializes an instance of {@link ProcedureNotFoundError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureCancelledError implements ProcedureError {
+/** When thrown, indicates that the operation was cancelled by the client. */
+export class ProcedureCancelledError extends ProcedureError {
     name = 'ProcedureCancelledError';
     code = ProcedureErrorCodes.CANCELLED;
-    message = 'The operation was cancelled by the client';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'The operation was cancelled by the client.';
+    /**
+     * Initializes an instance of {@link ProcedureCancelledError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureTimedOutError implements ProcedureError {
+/** When thrown, indicates that the request timed out waiting for the operation to complete. */
+export class ProcedureTimedOutError extends ProcedureError {
     name = 'ProcedureTimedOutError';
     code = ProcedureErrorCodes.TIMED_OUT;
-    message = 'Timed out waiting for the operation to complete';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'Timed out waiting for the operation to complete.';
+    /**
+     * Initializes an instance of {@link ProcedureTimedOutError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureInvalidResponseError implements ProcedureError {
+/** When thrown, indicates that the response from the server was invalid. */
+export class ProcedureInvalidResponseError extends ProcedureError {
     name = 'ProcedureInvalidResponseError';
     code = ProcedureErrorCodes.INVALID_RESPONSE;
-    message = 'The response from the server was invalid';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'The response from the server was invalid.';
+    /**
+     * Initializes an instance of {@link ProcedureInvalidResponseError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureInternalServerError implements ProcedureError {
+/** When thrown, indicates that an unhandled exception was thrown while attempting to handle the procedure. */
+export class ProcedureInternalServerError extends ProcedureError {
     name = 'ProcedureInternalServerError';
     code = ProcedureErrorCodes.INTERNAL_SERVER_ERROR;
-    message = 'An internal exception was thrown';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'An unhandled exception was thrown while attempting to handle the procedure.';
+    /**
+     * Initializes an instance of {@link ProcedureInternalServerError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
-export class ProcedureExecutionError implements ProcedureError {
+/** When thrown, indicates that an unhandled exception was thrown during procedure execution. */
+export class ProcedureExecutionError extends ProcedureError {
     name = 'ProcedureExecutionError';
     code = ProcedureErrorCodes.EXECUTION_ERROR;
-    message = 'An unhandled exception was thrown during procedure execution';
-    constructor(public data?: Record<string, unknown>) { }
+    message = 'An unhandled exception was thrown during procedure execution.';
+    /**
+     * Initializes an instance of {@link ProcedureExecutionError}.
+     * @param {Record<string, unknown>} [data] An optional dictionary of data which will be passed to a procedure's caller when thrown.
+     */
+     constructor(data?: Record<string, unknown>) { super(data) }
 }
 
 /**
- * Type guard for determining whether a given object is an `Error` instance.
+ * Type guard for determining whether a given {@link object} is an {@link Error} instance.
  * @param {unknown} object The object.
- * @returns {object is Error} `true` if the object is determined to be an `Error`, otherwise `false`.
+ * @returns {object is Error} `true` if the {@link object} is determined to be an {@link Error}, otherwise `false`.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
 export function isError(object: unknown): object is Error {
     return object instanceof Error;
 }
 
 /**
- * Type guard for determining whether a given object is `Error`-like, i.e. it matches the most basic `Error` interface.
+ * Type guard for determining whether a given {@link object} is {@link Error}-like, i.e. it conforms to the most basic {@link Error} interface.
  * @param {unknown} object The object.
- * @returns {object is Error} `true` if the object is determined to fit the shape of an `Error`, otherwise `false`.
+ * @returns {object is Error} `true` if the {@link object} conforms to the {@link Error} interface, otherwise `false`.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
 export function isErrorLike(object: unknown): object is Error {
     return typeof object === 'object' && object !== null && (isError(object) || 'name' in object);
 }
 
+/**
+ * Type guard for determining whether a given {@link object} conforms to the {@link ProcedureError} interface.
+ * @param {unknown} object The object.
+ * @returns {object is ProcedureError} `true` if the {@link object} conforms to the {@link ProcedureError} interface, otherwise `false`.
+ */
 export function isProcedureError(object: unknown): object is ProcedureError {
-    return isErrorLike(object) && object.name.startsWith('Procedure') && object.name.endsWith('Error')
+    return object instanceof ProcedureError || (isErrorLike(object) && object.name.startsWith('Procedure') && object.name.endsWith('Error')
         && 'message' in object
-        && 'code' in object && (<{ code: number }>object).code in ProcedureErrorCodes;
+        && 'code' in object && (<{ code: number }>object).code in ProcedureErrorCodes);
 }

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -221,6 +221,49 @@ export class Procedure<Input extends Nullable = undefined, Output extends Nullab
     }
 
     /**
+     * Asynchronously calls a {@link Procedure} at a given {@link endpoint} with given a {@link input}.
+     * If any errors are thrown, absorbs them and returns `void`.
+     * @param {string} endpoint The endpoint at which the {@link Procedure} is {@link Procedure.bind bound}.
+     * @param {Nullable} [input] An input parameter to pass to the {@link Procedure}. Defaults to `undefined`.
+     * @param {ProcedureCallOptions} [options={}] Options for calling a {@link Procedure}. Defaults to `{}`.
+     * @returns {Promise<Output | void>} A {@link Promise} which when resolved passes the output value to the {@link Promise.then then} handler(s). If errors were thrown,
+     * resolves to `void` (`undefined`) rather than rejecting.
+     * @template Output The type of output value expected to be returned from the {@link Procedure}. Defaults to `unknown`.
+     * @see {@link Procedure.endpoint}
+     * @see {@link Procedure.ping}
+     */
+    static async tryCall<Output extends Nullable = unknown>(endpoint: string, input?: Nullable, options: Partial<ProcedureCallOptions> = {}): Promise<Output | void> {
+        try {
+            return await Procedure.call<Output>(endpoint, input, options);
+        } catch {
+            return;
+        }
+    }
+
+    /**
+     * Asynchonously pings a {@link Procedure} at a given {@link endpoint} to check that it is available and ready to be {@link Procedure.call called}.
+     * If any errors are thrown, absorbs them and returns `false`.
+     * @param {string} endpoint The {@link Procedure.endpoint endpoint} to ping at which a {@link Procedure} is expected to be {@link Procedure.bind bound}.
+     * @param {number} [timeout=1000] How long to wait for a response before timing out.
+     * {@link NaN} or {@link Infinity infinite} values will result in the ping never timing out if no response is received, unless
+     * {@link signal} is a valid {@link AbortSignal} and gets aborted.
+     * Non-{@link NaN}, finite values will be clamped between `0` and {@link Number.MAX_SAFE_INTEGER} inclusive.
+     * Defaults to `1000`.
+     * @param {AbortSignal} [signal] An optional {@link AbortSignal} which, when passed, will be used to abort awaiting the ping.
+     * Defaults to `undefined`.
+     * @returns {Promise<void>} A {@link Promise} which when resolved indicated whether the {@link endpoint} is available and ready to handle {@link Procedure.call calls}.
+     * If errors were thrown, resolves to `false` instead of rejecting.
+     */
+    static async tryPing(endpoint: string, timeout = 1000, signal?: AbortSignal): Promise<boolean> {
+        try {
+            await Procedure.ping(endpoint, timeout, signal);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * 
      * @param endpoint 
      * @param input 

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -659,15 +659,18 @@ export type ProcedureEvents<Input extends Nullable = undefined> = {
 /**
  * A simple interface representing a ping.
  * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
 export interface Ping {
     ping: string;
 }
 
 /**
- * Type guard for determining whether a given object conforms to the `Ping` interface.
+ * Type guard for determining whether a given {@link object} conforms to the {@link Ping} interface.
  * @param {unknown} object The object.
- * @returns {object is Ping} `true` if the object conforms to the `Ping` interface, otherwise `false`.
+ * @returns {object is Ping} `true` if the {@link object} conforms to the {@link Ping} interface, otherwise `false`.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
 export function isPing(object: unknown): object is Ping {
     return typeof object === 'object' && object !== null && 'ping' in object && typeof (object as { ping: unknown }).ping === 'string';

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,5 +1,7 @@
 /**
  * A helper class to create an {@link AbortSignal} which aborts as soon as any of the signals passed to its constructor do.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future - possibly will be moved to its own package.
  */
 export class AggregateSignal {
     /** The aggregate {@link AbortSignal}. */
@@ -35,6 +37,8 @@ export class AggregateSignal {
 
 /**
  * A helper class to create an {@link AbortSignal} based on a timeout.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future - possibly will be moved to its own package.
  */
 export class TimeoutSignal {
     /** The underlying {@link AbortSignal}. */
@@ -60,9 +64,11 @@ export class TimeoutSignal {
 }
 
 /**
- * Type guard for determining whether a given object is an {@link AbortSignal} instance.
+ * Type guard for determining whether a given {@link object} is an {@link AbortSignal} instance.
  * @param {unknown} object The object.
  * @returns {object is AbortSignal} `true` if {@link object} is determined to be an {@link AbortSignal}, otherwise `false`.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
  export function isAbortSignal(object: unknown): object is AbortSignal {
     return object instanceof AbortSignal;
@@ -70,6 +76,8 @@ export class TimeoutSignal {
 
 /**
  * A helpful interface to allow use of {@link AbortSignal AbortSignal's} {@link EventTarget} interface when TypeScript hates us.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
 export interface Signal {
     addEventListener: (event: 'abort', callback: () => void) => void;
@@ -78,9 +86,11 @@ export interface Signal {
 }
 
 /**
- * Type guard for determining whether a given object conforms to the {@link Signal} interface.
+ * Type guard for determining whether a given {@link object} conforms to the {@link Signal} interface.
  * @param {unknown} object The object.
  * @returns {object is Signal} `true` if {@link object} conforms to the {@link Signal} interface, otherwise `false`.
+ * @internal
+ * @remarks Intended for internal use; may not be exported in future.
  */
 export function isSignal(object: unknown): object is Signal {
     return isAbortSignal(object) && 'addEventListener' in object && 'removeEventListener' in object

--- a/test/procedure.ts
+++ b/test/procedure.ts
@@ -847,6 +847,9 @@ describe('Procedure.ping(endpoint: string, timeout: number | undefined = 100, si
     });
 });
 
+// TODO: test Procedure.tryCall
+// TODO: test Procedure.tryPing
+
 describe('isPing(object: unknown): object is Ping', () => {
     let object: unknown;
 


### PR DESCRIPTION
- Adds two new static methods:
  - `async Procedure.tryPing`: wraps `Procedure.ping`, absorbing any thrown error messages and resolving into a boolean indicating whether the ping was successful.
  - `async Procedure.tryCall`: wraps `Procedure.call`, absorbing any thrown error messages and resolving into the expected `Output` on success, or `void` on failure.