### PR TITLE
Deprecate static methods in favour of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const procedure = new Procedure((n) => n ** 2).bind('tcp://*:5000');
 // some-other-app/index.js
 
 // calling the procedure to find the square of 8
-let squared = await Procedure.call('tcp://localhost:5000', 8);
+let squared = await call('tcp://localhost:5000', 8);
 console.log(squared); // outputs 64
 ```
 
@@ -75,7 +75,7 @@ procedure.bind('tcp://*:5000');
 And calling it is just as easy:
 ```js
 let x = 8;
-let xSquared = await Procedure.call('tcp://localhost:5000', x);
+let xSquared = await call('tcp://localhost:5000', x);
 console.log(xSquared); // outputs 64
 console.log(typeof xSquared); // outputs 'number'
 ```
@@ -110,11 +110,11 @@ const procedure = new Procedure(params => myFunction(...params))
 ```
 Which can then be called like so:
 ```js
-Procedure.call('tcp://localhost:30666', [1, 2, 3]);
+call('tcp://localhost:30666', [1, 2, 3]);
 ```
 For functions where you have optional parameters, it might make more sense to use object literals/property bags instead of arrays.
 
-Functions which accept multiple parameters where only the first is required (or none) will work as is, but you will only be able to pass the first parameter via `Procedure.call`.
+Functions which accept multiple parameters where only the first is required (or none) will work as is, but you will only be able to pass the first parameter via `call`.
 
 #### A note about `null` and `undefined`
 ##### Optional parameter support
@@ -133,7 +133,7 @@ const procedure = new Procedure(x => { ... }, { optionalParameterSupport: false 
 ```
 
 ```js
-await Procedure.call('tcp://*:54321', x, { optionalParameterSupport: false });
+await call('tcp://*:54321', x, { optionalParameterSupport: false });
 ```
 Note that disabling at the definition will not affect the return value, and disabling at the call will not affect the input parameter.
 
@@ -149,7 +149,7 @@ const procedure = new Procedure(x => { ... }, { ignoreUndefinedProperties: false
 ```
 
 ```js
-await Procedure.call('tcp://*:54321', x, { ignoreUndefinedProperties: false });
+await call('tcp://*:54321', x, { ignoreUndefinedProperties: false });
 ```
 Note that disabling at the definition will not affect the return value, and disabling at the call will not affect the input parameter.
 
@@ -164,7 +164,7 @@ const procedure = new Procedure(x => x.foo = 'bar')
 And then call it like so:
 ```js
 let obj = { foo: 123 };
-await Procedure.call('tcp://*:33333', obj);
+await call('tcp://*:33333', obj);
 console.log(obj); // outputs '{ foo: 123 }'
 ```
 The `obj` object would remain unchanged, because the procedure is acting on a *clone* of the object, not the object itself. First, the object is encoded for transmission by msgpack, then sent across the wire by nanomsg, and finally decoded by msgpack at the other end into a brand new object.
@@ -177,7 +177,7 @@ procedure.bind('tcp://*:5000');
 ```
 ```js
 let x = { foo: 'bar' };
-let xSquared = await Procedure.call('tcp://localhost:5000', x);
+let xSquared = await call('tcp://localhost:5000', x);
 // throws ProcedureExecutionError: An unhandled exception was thrown during procedure execution.
 ```
 
@@ -200,7 +200,7 @@ const procedure = new Procedure(n => {
 ```
 ```js
 let x = { foo: 'bar' };
-let xSquared = await Procedure.call('tcp://localhost:5000', x);
+let xSquared = await call('tcp://localhost:5000', x);
 // throws ProcedureExecutionError: Expected n to be a number, got 'object'
 ```
 
@@ -217,7 +217,7 @@ const procedure = new Procedure(n => {
 ```js
 let x = { foo: 'bar' }, xSquared;
 try {
-    xSquared = await Procedure.call('tcp://localhost:5000', x);
+    xSquared = await call('tcp://localhost:5000', x);
 } catch (e) {
     console.error(e?.name, '-', e?.message, e?.data);
 }
@@ -235,7 +235,7 @@ The full API reference for procedure.js is [available on GitHub Pages](https://p
 - [Initializing a procedure](https://procedure-rpc.github.io/procedure.js/classes/procedure.Procedure.html#constructor)
   - [Options](https://procedure-rpc.github.io/procedure.js/interfaces/procedure.ProcedureDefinitionOptions.html)
 - [Binding a procedure to an endpoint](https://procedure-rpc.github.io/procedure.js/classes/procedure.Procedure.html#bind)
-- [Calling a procedure](https://procedure-rpc.github.io/procedure.js/classes/procedure.Procedure.html#call)
+- [Calling a procedure](https://procedure-rpc.github.io/procedure.js/functions/procedure.call.html)
   - [Options](https://procedure-rpc.github.io/procedure.js/interfaces/procedure.ProcedureCallOptions.html)
 
 ## Transports: More than just TCP!
@@ -302,8 +302,8 @@ If you do need to make breaking changes to a procedure, it is recommended to eit
   ```
 
   ```js
-  const v1Result = await Procedure.call('tcp://localhost:33000'); // returns false
-  const v2Result = await Procedure.call('tcp://localhost:33001'); // returns undefined
+  const v1Result = await call('tcp://localhost:33000'); // returns false
+  const v2Result = await call('tcp://localhost:33001'); // returns undefined
   ```
 - use a parameter or property to specify a version modifier, defaulting to the original when unspecified:
   ```js
@@ -331,8 +331,8 @@ If you do need to make breaking changes to a procedure, it is recommended to eit
   ```
 
   ```js
-  const v1Result = await Procedure.call('tcp://localhost:33000'); // returns false
-  const v2Result = await Procedure.call('tcp://localhost:33000', { version: 2 }); //returns undefined
+  const v1Result = await call('tcp://localhost:33000'); // returns false
+  const v2Result = await call('tcp://localhost:33000', { version: 2 }); //returns undefined
   ```
 
   You may prefer to use a [semver](https://www.npmjs.com/package/semver) compatible string for versioning.

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -7,7 +7,7 @@ import {
 } from './errors';
 import { AggregateSignal, TimeoutSignal } from './signals';
 import { createSocket, Socket } from 'nanomsg';
-import { encode, decode, ExtensionCodec } from '@msgpack/msgpack'
+import { encode as msgpackEncode, decode as msgpackDecode, ExtensionCodec } from '@msgpack/msgpack'
 import { once, EventEmitter } from 'events'
 import TypedEmitter from 'typed-emitter'
 import { v5 as uuidv5 } from 'uuid';
@@ -146,95 +146,17 @@ export class Procedure<Input extends Nullable = undefined, Output extends Nullab
     }
 
     /**
-     * Asynchronously calls a {@link Procedure} at a given {@link endpoint} with given a {@link input}.
-     * @param {string} endpoint The endpoint at which the {@link Procedure} is {@link Procedure.bind bound}.
-     * @param {Nullable} [input] An input parameter to pass to the {@link Procedure}. Defaults to `undefined`.
-     * @param {Partial<ProcedureCallOptions>} [options={}] Options for calling a {@link Procedure}. Defaults to `{}`.
-     * @returns {Promise<Output>} A {@link Promise} which when resolved passes the output value to the {@link Promise.then then} handler(s).
-     * @template Output The type of output value expected to be returned from the {@link Procedure}. Defaults to `unknown`.
-     * @see {@link Procedure.endpoint}
-     * @see {@link Procedure.ping}
+     * @deprecated alias of {@link call}. Slated for removal from API by v1.0
      */
-    static async call<Output extends Nullable = unknown>(endpoint: string, input?: Nullable, options: Partial<ProcedureCallOptions> = {}): Promise<Output> {
-        try {
-            const opts: ProcedureCallOptions = {
-                ...{
-                    timeout: 1000,
-                    optionalParameterSupport: true,
-                    ignoreUndefinedProperties: true
-                },
-                ...options
-            };
-
-            if (opts.ping !== undefined) {
-                await Procedure.ping(endpoint, opts.ping, opts.signal);
-            }
-
-            const response = await Procedure.#getResponse<Output>(endpoint, input, opts);
-
-            if ('output' in response && !('error' in response)) {
-                return response.output ?? <Output>(opts.optionalParameterSupport
-                    ? undefined
-                    : response.output);
-            } else if (isProcedureError(response.error)) {
-                throw response.error;
-            } else {
-                throw new ProcedureInvalidResponseError();
-            }
-        } catch (error) {
-            throw isProcedureError(error)
-                ? error
-                : new ProcedureInternalClientError();
-        }
-    }
+    static call = call;
 
     /**
-     * Asynchonously pings a {@link Procedure} at a given {@link endpoint} to check that it is available and ready to be {@link Procedure.call called}.
-     * @param {string} endpoint The {@link Procedure.endpoint endpoint} to ping at which a {@link Procedure} is expected to be {@link Procedure.bind bound}.
-     * @param {number} [timeout=1000] How long to wait for a response before timing out.
-     * {@link NaN} or {@link Infinity infinite} values will result in the ping never timing out if no response is received, unless
-     * {@link signal} is a valid {@link AbortSignal} and gets aborted.
-     * Non-{@link NaN}, finite values will be clamped between `0` and {@link Number.MAX_SAFE_INTEGER} inclusive.
-     * Defaults to `1000`.
-     * @param {AbortSignal} [signal] An optional {@link AbortSignal} which, when passed, will be used to abort awaiting the ping.
-     * Defaults to `undefined`.
-     * @returns {Promise<void>} A {@link Promise} which when resolved indicates that the {@link endpoint} is available and ready to handle
-     * {@link Procedure.call calls}.
+     * @deprecated alias of {@link ping}. Slated for removal from API by v1.0
      */
-    static async ping(endpoint: string, timeout = 1000, signal?: AbortSignal): Promise<void> {
-        try {
-            const ping = uuidv5(endpoint, uuidNamespace);
-            const response = await Procedure.#getResponse<{ pong: string }>(endpoint, { ping }, {
-                timeout,
-                signal,
-                ignoreUndefinedProperties: false,
-                optionalParameterSupport: false
-            });
-
-            if (response?.pong !== ping) {
-                throw new ProcedureInvalidResponseError();
-            }
-        } catch (error) {
-            throw isProcedureError(error)
-                ? error
-                : new ProcedureInternalClientError();
-        }
-    }
+    static ping = ping;
 
     /**
-     * Asynchonously pings a {@link Procedure} at a given {@link endpoint} to check that it is available and ready to be {@link Procedure.call called}.
-     * If any errors are thrown, absorbs them and returns `false`.
-     * @param {string} endpoint The {@link Procedure.endpoint endpoint} to ping at which a {@link Procedure} is expected to be {@link Procedure.bind bound}.
-     * @param {number} [timeout=1000] How long to wait for a response before timing out.
-     * {@link NaN} or {@link Infinity infinite} values will result in the ping never timing out if no response is received, unless
-     * {@link signal} is a valid {@link AbortSignal} and gets aborted.
-     * Non-{@link NaN}, finite values will be clamped between `0` and {@link Number.MAX_SAFE_INTEGER} inclusive.
-     * Defaults to `1000`.
-     * @param {AbortSignal} [signal] An optional {@link AbortSignal} which, when passed, will be used to abort awaiting the ping.
-     * Defaults to `undefined`.
-     * @returns {Promise<void>} A {@link Promise} which when resolved indicated whether the {@link endpoint} is available and ready to handle
-     * {@link Procedure.call calls}.
-     * If errors were thrown, resolves to `false` instead of rejecting.
+     * @deprecated alias of {@link tryPing}. Slated for removal from API by v1.0
      */
     static async tryPing(endpoint: string, timeout = 1000, signal?: AbortSignal): Promise<boolean> {
         try {
@@ -246,77 +168,13 @@ export class Procedure<Input extends Nullable = undefined, Output extends Nullab
     }
 
     /**
-     * Asynchronously encodes and transmits the given {@link input} to the {@link endpoint} and retrieves the response.
-     * @param {string} endpoint The endpoint at which the {@link Procedure} is {@link Procedure.bind bound}.
-     * @param {Nullable} input An input parameter to pass to the {@link Procedure}.
-     * @param {ProcedureCallOptions} options Options for calling a {@link Procedure}.
-     * @returns {Promise<Response<Output>>} A {@link Promise} which when resolved passes the {@link Response<Output> response} to the
-     * {@link Promise.then then} handler(s).
-     * @template Output The type of output value expected to be returned from the {@link Procedure}. Defaults to `unknown`.
-     */
-    static async #getResponse<Output extends Nullable = unknown>(endpoint: string, input: Nullable, options: ProcedureCallOptions): Promise<Response<Output>> {
-        let socket: Socket | undefined;
-        let timeoutSignal: TimeoutSignal | undefined = undefined;
-
-        try {
-            if (options.signal?.aborted) {
-                throw new ProcedureCancelledError();
-            }
-
-            timeoutSignal = new TimeoutSignal(options.timeout);
-            const signal = new AggregateSignal(options.signal, timeoutSignal.signal).signal;
-
-            socket = createSocket('req');
-            socket.connect(endpoint);
-            socket.send(Procedure.#encode(input, options.extensionCodec, options.ignoreUndefinedProperties)); // send the encoded input data to the endpoint
-
-            const [buffer]: [Buffer] = await once(socket, 'data', { signal }) as [Buffer]; // await buffered response
-            return Procedure.#decode<Response<Output>>(buffer, options.extensionCodec); // decode response from buffer
-        } catch (e) {
-            if (isProcedureError(e)) {
-                throw e;
-            } else if (isError(e) && e.name === 'AbortError') {
-                throw new ProcedureCancelledError();
-            } else {
-                throw new ProcedureInternalClientError();
-            }
-        } finally {
-            clearTimeout(timeoutSignal?.timeout); // clear the TimeoutSignal's timeout, if any
-            socket?.removeAllListeners().close(); // clear all listeners and close the socket
-        }
-    }
-
-    /**
-     * Encodes a given value for transmission.
-     * @param {unknown} value The value to be encoded.
-     * @param {ExtensionCodec} [extensionCodec] The {@link ExtensionCodec} to use for encoding.
-     * @param {boolean} [ignoreUndefinedProperties=false] Whether to strip `undefined` properties from objects or not.
-     * @returns {Buffer} A {@link Buffer} containing the encoded value.
-     */
-    static #encode(value: unknown, extensionCodec?: ExtensionCodec, ignoreUndefinedProperties = false): Buffer {
-        const encoded = encode(value, { extensionCodec, ignoreUndefined: ignoreUndefinedProperties });
-        return Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength);
-    }
-
-    /**
-     * Decodes a given {@link Buffer} and casts it as {@link T}.
-     * @param {Buffer} buffer The {@link Buffer} to be decoded.
-     * @param {ExtensionCodec} [extensionCodec] The {@link ExtensionCodec} to use for decoding.
-     * @returns {T} The buffer, decoded and cast to type {@link T}.
-     * @template T The type the decoded value should be cast to.
-     */
-    static #decode <T = unknown>(buffer: Buffer, extensionCodec?: ExtensionCodec): T {
-        return decode(buffer, { extensionCodec }) as T;
-    }
-
-    /**
      * Attempts to decode the given {@link Buffer}.
      * @param {Buffer} buffer The {@link Buffer} to decode.
      * @returns {{ input: Input, error?: never } | { input?: never, error: unknown }} If successful, an object of shape `{ input: Input | Ping }`, otherwise `{ error: unknown }`.
      */
     #tryDecodeInput(buffer: Buffer): { input: Input | Ping, error?: never } | { input?: never, error: ProcedureInternalServerError } {
         try {
-            return { input: Procedure.#decode<Input | Ping>(buffer, this.extensionCodec) };
+            return { input: decode<Input | Ping>(buffer, this.extensionCodec) };
         } catch (e) {
             const error = new ProcedureInternalServerError(undefined, { error: e });
             this.#emitAndLogError('Procedure input data could not be decoded', error);
@@ -359,7 +217,7 @@ export class Procedure<Input extends Nullable = undefined, Output extends Nullab
      */
     #tryEncodeResponse(response: Response<Output>): Buffer {
         try {
-            return Procedure.#encode(response, this.extensionCodec, this.ignoreUndefinedProperties);
+            return encode(response, this.extensionCodec, this.ignoreUndefinedProperties);
         } catch (e) {
             const error = new ProcedureInternalServerError(undefined, { error: e });
             this.#emitAndLogError('Procedure response could not be encoded for transmission', error);
@@ -658,4 +516,169 @@ export interface Ping {
  */
 export function isPing(object: unknown): object is Ping {
     return typeof object === 'object' && object !== null && 'ping' in object && typeof (object as { ping: unknown }).ping === 'string';
+}
+
+/**
+ * Asynchronously calls a {@link Procedure} at a given {@link endpoint} with given a {@link input}.
+ * @param {string} endpoint The endpoint at which the {@link Procedure} is {@link Procedure.bind bound}.
+ * @param {Nullable} [input] An input parameter to pass to the {@link Procedure}. Defaults to `undefined`.
+ * @param {Partial<ProcedureCallOptions>} [options={}] Options for calling a {@link Procedure}. Defaults to `{}`.
+ * @returns {Promise<Output>} A {@link Promise} which when resolved passes the output value to the {@link Promise.then then} handler(s).
+ * @template Output The type of output value expected to be returned from the {@link Procedure}. Defaults to `unknown`.
+ * @see {@link Procedure.endpoint}
+ * @see {@link Procedure.ping}
+ */
+export async function call<Output extends Nullable = unknown>(endpoint: string, input?: Nullable, options: Partial<ProcedureCallOptions> = {}): Promise<Output> {
+    try {
+        const opts: ProcedureCallOptions = {
+            ...{
+                timeout: 1000,
+                optionalParameterSupport: true,
+                ignoreUndefinedProperties: true
+            },
+            ...options
+        };
+
+        if (opts.ping !== undefined) {
+            await Procedure.ping(endpoint, opts.ping, opts.signal);
+        }
+
+        const response = await getResponse<Output>(endpoint, input, opts);
+
+        if ('output' in response && !('error' in response)) {
+            return response.output ?? <Output>(opts.optionalParameterSupport
+                ? undefined
+                : response.output);
+        } else if (isProcedureError(response.error)) {
+            throw response.error;
+        } else {
+            throw new ProcedureInvalidResponseError();
+        }
+    } catch (error) {
+        throw isProcedureError(error)
+            ? error
+            : new ProcedureInternalClientError();
+    }
+}
+
+/**
+ * Asynchonously pings a {@link Procedure} at a given {@link endpoint} to check that it is available and ready to be {@link Procedure.call called}.
+ * @param {string} endpoint The {@link Procedure.endpoint endpoint} to ping at which a {@link Procedure} is expected to be {@link Procedure.bind bound}.
+ * @param {number} [timeout=1000] How long to wait for a response before timing out.
+ * {@link NaN} or {@link Infinity infinite} values will result in the ping never timing out if no response is received, unless
+ * {@link signal} is a valid {@link AbortSignal} and gets aborted.
+ * Non-{@link NaN}, finite values will be clamped between `0` and {@link Number.MAX_SAFE_INTEGER} inclusive.
+ * Defaults to `1000`.
+ * @param {AbortSignal} [signal] An optional {@link AbortSignal} which, when passed, will be used to abort awaiting the ping.
+ * Defaults to `undefined`.
+ * @returns {Promise<void>} A {@link Promise} which when resolved indicates that the {@link endpoint} is available and ready to handle
+ * {@link Procedure.call calls}.
+ */
+export async function ping(endpoint: string, timeout = 1000, signal?: AbortSignal): Promise<void> {
+    try {
+        const ping = uuidv5(endpoint, uuidNamespace);
+        const response = await getResponse<{ pong: string }>(endpoint, { ping }, {
+            timeout,
+            signal,
+            ignoreUndefinedProperties: false,
+            optionalParameterSupport: false
+        });
+
+        if (response?.pong !== ping) {
+            throw new ProcedureInvalidResponseError();
+        }
+    } catch (error) {
+        throw isProcedureError(error)
+            ? error
+            : new ProcedureInternalClientError();
+    }
+}
+
+/**
+ * Asynchonously pings a {@link Procedure} at a given {@link endpoint} to check that it is available and ready to be {@link Procedure.call called}.
+ * If any errors are thrown, absorbs them and returns `false`.
+ * @param {string} endpoint The {@link Procedure.endpoint endpoint} to ping at which a {@link Procedure} is expected to be {@link Procedure.bind bound}.
+ * @param {number} [timeout=1000] How long to wait for a response before timing out.
+ * {@link NaN} or {@link Infinity infinite} values will result in the ping never timing out if no response is received, unless
+ * {@link signal} is a valid {@link AbortSignal} and gets aborted.
+ * Non-{@link NaN}, finite values will be clamped between `0` and {@link Number.MAX_SAFE_INTEGER} inclusive.
+ * Defaults to `1000`.
+ * @param {AbortSignal} [signal] An optional {@link AbortSignal} which, when passed, will be used to abort awaiting the ping.
+ * Defaults to `undefined`.
+ * @returns {Promise<void>} A {@link Promise} which when resolved indicated whether the {@link endpoint} is available and ready to handle
+ * {@link Procedure.call calls}.
+ * If errors were thrown, resolves to `false` instead of rejecting.
+ */
+export async function tryPing(endpoint: string, timeout = 1000, signal?: AbortSignal): Promise<boolean> {
+    try {
+        await ping(endpoint, timeout, signal);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+
+/**
+ * Asynchronously encodes and transmits the given {@link input} to the {@link endpoint} and retrieves the response.
+ * @param {string} endpoint The endpoint at which the {@link Procedure} is {@link Procedure.bind bound}.
+ * @param {Nullable} input An input parameter to pass to the {@link Procedure}.
+ * @param {ProcedureCallOptions} options Options for calling a {@link Procedure}.
+ * @returns {Promise<Response<Output>>} A {@link Promise} which when resolved passes the {@link Response<Output> response} to the
+ * {@link Promise.then then} handler(s).
+ * @template Output The type of output value expected to be returned from the {@link Procedure}. Defaults to `unknown`.
+ */
+async function getResponse<Output extends Nullable = unknown>(endpoint: string, input: Nullable, options: ProcedureCallOptions): Promise<Response<Output>> {
+    let socket: Socket | undefined;
+    let timeoutSignal: TimeoutSignal | undefined = undefined;
+
+    try {
+        if (options.signal?.aborted) {
+            throw new ProcedureCancelledError();
+        }
+
+        timeoutSignal = new TimeoutSignal(options.timeout);
+        const signal = new AggregateSignal(options.signal, timeoutSignal.signal).signal;
+
+        socket = createSocket('req');
+        socket.connect(endpoint);
+        socket.send(encode(input, options.extensionCodec, options.ignoreUndefinedProperties)); // send the encoded input data to the endpoint
+
+        const [buffer]: [Buffer] = await once(socket, 'data', { signal }) as [Buffer]; // await buffered response
+        return decode<Response<Output>>(buffer, options.extensionCodec); // decode response from buffer
+    } catch (e) {
+        if (isProcedureError(e)) {
+            throw e;
+        } else if (isError(e) && e.name === 'AbortError') {
+            throw new ProcedureCancelledError();
+        } else {
+            throw new ProcedureInternalClientError();
+        }
+    } finally {
+        clearTimeout(timeoutSignal?.timeout); // clear the TimeoutSignal's timeout, if any
+        socket?.removeAllListeners().close(); // clear all listeners and close the socket
+    }
+}
+
+/**
+ * Encodes a given value for transmission.
+ * @param {unknown} value The value to be encoded.
+ * @param {ExtensionCodec} [extensionCodec] The {@link ExtensionCodec} to use for encoding.
+ * @param {boolean} [ignoreUndefinedProperties=false] Whether to strip `undefined` properties from objects or not.
+ * @returns {Buffer} A {@link Buffer} containing the encoded value.
+ */
+function encode(value: unknown, extensionCodec?: ExtensionCodec, ignoreUndefinedProperties = false): Buffer {
+    const encoded = msgpackEncode(value, { extensionCodec, ignoreUndefined: ignoreUndefinedProperties });
+    return Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength);
+}
+
+/**
+ * Decodes a given {@link Buffer} and casts it as {@link T}.
+ * @param {Buffer} buffer The {@link Buffer} to be decoded.
+ * @param {ExtensionCodec} [extensionCodec] The {@link ExtensionCodec} to use for decoding.
+ * @returns {T} The buffer, decoded and cast to type {@link T}.
+ * @template T The type the decoded value should be cast to.
+ */
+function decode<T = unknown>(buffer: Buffer, extensionCodec?: ExtensionCodec): T {
+    return msgpackDecode(buffer, { extensionCodec }) as T;
 }

--- a/test/procedure.ts
+++ b/test/procedure.ts
@@ -2,7 +2,7 @@ import 'mocha'
 import chai, { expect } from 'chai'
 import spies from 'chai-spies'
 import chaiAsPromised from 'chai-as-promised'
-import Procedure, { Callback, isPing } from '../src'
+import Procedure, { call, ping, tryPing, Callback, isPing } from '../src'
 import { ExtensionCodec } from '@msgpack/msgpack'
 import { ProcedureInternalServerError } from '../src/errors'
 
@@ -218,7 +218,7 @@ describe('Procedure', () => {
     });
 });
 
-describe('Procedure.call(endpoint: string, input: Input | null, options: Partial<ProcedureCallOptions>): Promise<Output>', () => {
+describe('call(endpoint: string, input: Input | null, options: Partial<ProcedureCallOptions>): Promise<Output>', () => {
     let func: Callback<unknown, unknown>;
     let spy: ChaiSpies.SpyFunc1<unknown, unknown>;
     let procedure: Procedure<unknown, unknown>;
@@ -253,12 +253,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(0));
+                    it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(0));
 
                     afterEach(() => input = undefined);
 
@@ -270,7 +270,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -284,7 +284,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -293,7 +293,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(input));
+                    it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(input));
 
                     afterEach(() => input = undefined);
                 });
@@ -301,7 +301,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -313,12 +313,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
+                        it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
 
                         afterEach(() => input = undefined);
 
@@ -330,7 +330,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -344,7 +344,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -353,7 +353,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
+                        it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
 
                         afterEach(() => input = undefined);
                     });
@@ -361,7 +361,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -399,12 +399,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -417,7 +417,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -431,7 +431,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -440,7 +440,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -449,7 +449,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -461,12 +461,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -479,7 +479,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -493,7 +493,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -502,7 +502,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -511,7 +511,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -549,12 +549,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -567,7 +567,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -581,7 +581,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -590,7 +590,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -599,7 +599,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -611,12 +611,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -629,7 +629,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -643,7 +643,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -652,7 +652,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -661,7 +661,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -713,12 +713,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(0));
+                    it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(0));
 
                     afterEach(() => input = undefined);
 
@@ -730,7 +730,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -744,7 +744,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -753,7 +753,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(input));
+                    it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(input));
 
                     afterEach(() => input = undefined);
                 });
@@ -761,7 +761,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -773,12 +773,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
+                        it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
 
                         afterEach(() => input = undefined);
 
@@ -790,7 +790,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -804,7 +804,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -813,7 +813,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
+                        it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
 
                         afterEach(() => input = undefined);
                     });
@@ -821,7 +821,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -859,12 +859,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -877,7 +877,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -891,7 +891,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -900,7 +900,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -909,7 +909,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -921,12 +921,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -939,7 +939,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -953,7 +953,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -962,7 +962,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -971,7 +971,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1009,12 +1009,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1027,7 +1027,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1041,7 +1041,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1050,7 +1050,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1059,7 +1059,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1071,12 +1071,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1089,7 +1089,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -1103,7 +1103,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -1112,7 +1112,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1121,7 +1121,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1162,12 +1162,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(0));
+                    it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(0));
 
                     afterEach(() => input = undefined);
 
@@ -1179,7 +1179,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1193,7 +1193,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1202,7 +1202,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(input));
+                    it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(input));
 
                     afterEach(() => input = undefined);
                 });
@@ -1210,7 +1210,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1222,12 +1222,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
+                        it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
 
                         afterEach(() => input = undefined);
 
@@ -1239,7 +1239,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -1253,7 +1253,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -1262,7 +1262,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
+                        it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
 
                         afterEach(() => input = undefined);
                     });
@@ -1270,7 +1270,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1308,12 +1308,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1326,7 +1326,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1340,7 +1340,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1349,7 +1349,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1358,7 +1358,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1370,12 +1370,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1388,7 +1388,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -1402,7 +1402,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -1411,7 +1411,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1420,7 +1420,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1458,12 +1458,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1476,7 +1476,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1490,7 +1490,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1499,7 +1499,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1508,7 +1508,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1520,12 +1520,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1538,7 +1538,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -1552,7 +1552,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -1561,7 +1561,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1570,7 +1570,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1611,12 +1611,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(0));
+                    it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(0));
 
                     afterEach(() => input = undefined);
 
@@ -1628,7 +1628,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1642,7 +1642,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1651,7 +1651,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input)).to.eventually.equal(input));
+                    it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input)).to.eventually.equal(input));
 
                     afterEach(() => input = undefined);
                 });
@@ -1659,7 +1659,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1671,12 +1671,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: 0', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
+                        it('should resolve: 0', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(0));
 
                         afterEach(() => input = undefined);
 
@@ -1688,7 +1688,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -1702,7 +1702,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -1711,7 +1711,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: 1000', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
+                        it('should resolve: 1000', async () => await expect(call(<string>callEndpoint, input, { ping: 100 })).to.eventually.equal(input));
 
                         afterEach(() => input = undefined);
                     });
@@ -1719,7 +1719,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1757,12 +1757,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1775,7 +1775,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1789,7 +1789,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1798,7 +1798,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1807,7 +1807,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1819,12 +1819,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1837,7 +1837,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -1851,7 +1851,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -1860,7 +1860,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1869,7 +1869,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -1907,12 +1907,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         let x: unknown = undefined;
                         const data = chai.spy((data: unknown) => x = data);
                         procedure.on('data', data);
-                        await Procedure.call(<string>callEndpoint, input);
+                        await call(<string>callEndpoint, input);
                         expect(data).to.have.been.called.once;
                         expect(x).to.equal(0);
                     });
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1925,7 +1925,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                         });
 
                         it('should call console.log', async () => {
-                            await Procedure.call(<string>callEndpoint, input);
+                            await call(<string>callEndpoint, input);
                             expect(console.log).to.have.been.called.exactly(3);
                         });
 
@@ -1939,7 +1939,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: \'foo\'', () => {
                     beforeEach(() => input = 'foo');
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                     afterEach(() => input = undefined);
@@ -1948,7 +1948,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: 1000', () => {
                     beforeEach(() => input = 1000);
 
-                    it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input))
                         .to.eventually.be.undefined);
 
                     afterEach(() => input = undefined);
@@ -1957,7 +1957,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                 context('when input: undefined', () => {
                     beforeEach(() => input = undefined);
 
-                    it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input))
+                    it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input))
                         .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                 });
 
@@ -1969,12 +1969,12 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             let x: unknown = undefined;
                             const data = chai.spy((data: unknown) => x = data);
                             procedure.on('data', data);
-                            await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                            await call(<string>callEndpoint, input, { ping: 100 });
                             expect(data).to.have.been.called.once;
                             expect(x).to.equal(0);
                         });
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -1987,7 +1987,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                             });
 
                             it('should call console.log', async () => {
-                                await Procedure.call(<string>callEndpoint, input, { ping: 100 });
+                                await call(<string>callEndpoint, input, { ping: 100 });
                                 expect(console.log).to.have.been.called.exactly(5);
                             });
 
@@ -2001,7 +2001,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: \'foo\'', () => {
                         beforeEach(() => input = 'foo');
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
 
                         afterEach(() => input = undefined);
@@ -2010,7 +2010,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: 1000', () => {
                         beforeEach(() => input = 1000);
 
-                        it('should resolve: undefined', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should resolve: undefined', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.eventually.be.undefined);
 
                         afterEach(() => input = undefined);
@@ -2019,7 +2019,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
                     context('when input: undefined', () => {
                         beforeEach(() => input = undefined);
 
-                        it('should throw: ProcedureExecutionError', async () => await expect(Procedure.call(<string>callEndpoint, input, { ping: 100 }))
+                        it('should throw: ProcedureExecutionError', async () => await expect(call(<string>callEndpoint, input, { ping: 100 }))
                             .to.be.rejectedWith('An unhandled exception was thrown during procedure execution'));
                     });
                 });
@@ -2034,7 +2034,7 @@ describe('Procedure.call(endpoint: string, input: Input | null, options: Partial
     });
 });
 
-describe('Procedure.ping(endpoint: string, timeout: number | undefined = 100, signal?: AbortSignal): Promise<boolean>', () => {
+describe('ping(endpoint: string, timeout: number | undefined = 100, signal?: AbortSignal): Promise<boolean>', () => {
     let func: Callback<unknown, unknown>;
     let spy: ChaiSpies.SpyFunc1<unknown, unknown>;
     let procedure: Procedure<unknown, unknown>;
@@ -2063,11 +2063,11 @@ describe('Procedure.ping(endpoint: string, timeout: number | undefined = 100, si
             it('should not emit: data', async () => {
                 const data = chai.spy(() => { return });
                 procedure.on('data', data);
-                await Procedure.ping(<string>pingEndpoint);
+                await ping(<string>pingEndpoint);
                 expect(data).to.have.been.called.exactly(0);
             });
 
-            it('should not be rejected', async () => await expect(Procedure.ping(<string>pingEndpoint)).to.not.be.rejected);
+            it('should not be rejected', async () => await expect(ping(<string>pingEndpoint)).to.not.be.rejected);
 
             context('when signal: already aborted AbortSignal', () => {
                 let ac: AbortController;
@@ -2077,7 +2077,7 @@ describe('Procedure.ping(endpoint: string, timeout: number | undefined = 100, si
                     ac.abort();
                 });
 
-                it('should throw: ProcedureCancelledError', async () => await expect(Procedure.ping(<string>pingEndpoint, 500, ac.signal))
+                it('should throw: ProcedureCancelledError', async () => await expect(ping(<string>pingEndpoint, 500, ac.signal))
                     .to.be.rejectedWith('The operation was cancelled by the client'));
             });
         });
@@ -2090,7 +2090,7 @@ describe('Procedure.ping(endpoint: string, timeout: number | undefined = 100, si
     });
 });
 
-describe('Procedure.tryPing(endpoint: string, timeout: number | undefined = 100, signal?: AbortSignal): Promise<boolean>', () => {
+describe('tryPing(endpoint: string, timeout: number | undefined = 100, signal?: AbortSignal): Promise<boolean>', () => {
     let func: Callback<unknown, unknown>;
     let spy: ChaiSpies.SpyFunc1<unknown, unknown>;
     let procedure: Procedure<unknown, unknown>;
@@ -2119,11 +2119,11 @@ describe('Procedure.tryPing(endpoint: string, timeout: number | undefined = 100,
             it('should not emit: data', async () => {
                 const data = chai.spy(() => { return });
                 procedure.on('data', data);
-                await Procedure.tryPing(<string>pingEndpoint);
+                await tryPing(<string>pingEndpoint);
                 expect(data).to.have.been.called.exactly(0);
             });
 
-            it('should resolve: true', async () => await expect(Procedure.tryPing(<string>pingEndpoint)).to.eventually.be.true.and.to.not.be.rejected);
+            it('should resolve: true', async () => await expect(tryPing(<string>pingEndpoint)).to.eventually.be.true.and.to.not.be.rejected);
 
             context('when signal: already aborted AbortSignal', () => {
                 let ac: AbortController;
@@ -2133,7 +2133,7 @@ describe('Procedure.tryPing(endpoint: string, timeout: number | undefined = 100,
                     ac.abort();
                 });
 
-                it('should resolve: false', async () => await expect(Procedure.tryPing(<string>pingEndpoint, 500, ac.signal))
+                it('should resolve: false', async () => await expect(tryPing(<string>pingEndpoint, 500, ac.signal))
                     .to.eventually.be.false.and.to.not.be.rejected);
             });
         });


### PR DESCRIPTION
- static methods on `Procedure` have been moved to functions: `call`, `ping`, `tryPing`.
- The static methods are still available for legacy use, but are marked as `deprecated`. They are slated to be removed from the API by v1.0.

Old way:
```js
const Procedure = require('@procedure-rpc/procedure.js);
Procedure.call("tcp://localhost:33333");
```

New way:
```js
const { call } = require('@procedure-rpc/procedure.js):
call("tcp://localhost:33333");
```