### PR TITLE
Hotfix: `ProcedureTimedOutError` not being thrown when it should

### DIFF
--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -695,7 +695,7 @@ async function getResponse<Output extends Nullable = unknown>(endpoint: string, 
         if (isProcedureError(e)) {
             throw e;
         } else if (isError(e) && e.name === 'AbortError') {
-            throw aggregateSignal?.abortedSignal === timeoutSignal
+            throw aggregateSignal?.abortedSignal === timeoutSignal?.signal
                 ? new ProcedureTimedOutError()
                 : new ProcedureCancelledError();
         } else {


### PR DESCRIPTION
## Changes in this pull request
- hotfix c3ad6b45b6aea6c3be4908f426951dbe5a463adb
  Fixes an issue where `ProcedureTimedOutError` would not be thrown when it should.