### PR TITLE
Add `typedoc-plugin-versions-cli` for improved docs CI/CD

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        version: [lts/*, latest]
+        version: [lts/*]
 
     steps:
       - name: Checkout repository

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,9 @@
         "prettier": "2.7.1",
         "ts-jest": "^28.0.8",
         "typed-emitter": "^2.1.0",
-        "typedoc": "^0.23.14",
-        "typedoc-plugin-versions": "^0.2.0",
+        "typedoc": "^0.23.15",
+        "typedoc-plugin-versions": "^0.2.1",
+        "typedoc-plugin-versions-cli": "^0.1.5",
         "typescript": "^4.8.0"
       },
       "engines": {
@@ -1745,6 +1746,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
     "node_modules/babel-jest": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
@@ -1997,6 +2004,99 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/cli-diff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-diff/-/cli-diff-1.0.0.tgz",
+      "integrity": "sha512-XOVrll4VMhxBv26WqV6OH9cWqRxBXthh3uZ3dtg+CLqB8m0R6QJiSoDIXQNXDAeo/FAkQ+kF9Ph8NhQskU3LpQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "diff": "^3.5.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-diff/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-diff/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-diff/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/cli-diff/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/cli-diff/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/cli-diff/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/cli-diff/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-diff/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -4879,9 +4979,9 @@
       }
     },
     "node_modules/typedoc-plugin-versions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-versions/-/typedoc-plugin-versions-0.2.0.tgz",
-      "integrity": "sha512-riDfd2+meM1+idHk60pwKgxZnXZhwqSRtY0bYIOSGmTv4paBOuZL0H75Jd/EA099KtEVdvs3sJNl6MizLCUnKQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-versions/-/typedoc-plugin-versions-0.2.1.tgz",
+      "integrity": "sha512-JWNziM5ATtXa9jSnul1a8mlEfoAZX5NGekCz1rVJ/2RyAAfeHYM7LVQmTzmHPdXMfoJH56oJMgINLJ2Ri2SARQ==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^10.1.0",
@@ -4893,6 +4993,47 @@
       },
       "peerDependencies": {
         "typedoc": "^0.23"
+      }
+    },
+    "node_modules/typedoc-plugin-versions-cli": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-versions-cli/-/typedoc-plugin-versions-cli-0.1.5.tgz",
+      "integrity": "sha512-vKmqxljKX4FRICO2Ana1j+gSC9Y+LyVeE0ThMP3j1wtSXnZhP5t53OA65n+nL0JXDdiImZfU0EbL1pTM3a+/uQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/toebeann"
+        },
+        {
+          "type": "individual",
+          "url": "https://paypal.me/tobeyblaber"
+        }
+      ],
+      "os": [
+        "win32",
+        "linux",
+        "darwin"
+      ],
+      "dependencies": {
+        "async": "^3.2.4",
+        "cli-diff": "^1.0.0",
+        "prompts": "^2.4.2",
+        "semver": "^7.3.7",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "tpv": "dist/cli.js",
+        "typedoc-plugin-versions": "dist/cli.js",
+        "typedoc-plugin-versions-cli": "dist/cli.js",
+        "typedoc-versions": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typedoc": "^0.23",
+        "typedoc-plugin-versions": "^0.2"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -6431,6 +6572,12 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
     "babel-jest": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
@@ -6615,6 +6762,80 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "cli-diff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-diff/-/cli-diff-1.0.0.tgz",
+      "integrity": "sha512-XOVrll4VMhxBv26WqV6OH9cWqRxBXthh3uZ3dtg+CLqB8m0R6QJiSoDIXQNXDAeo/FAkQ+kF9Ph8NhQskU3LpQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "diff": "^3.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -8760,13 +8981,26 @@
       }
     },
     "typedoc-plugin-versions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-versions/-/typedoc-plugin-versions-0.2.0.tgz",
-      "integrity": "sha512-riDfd2+meM1+idHk60pwKgxZnXZhwqSRtY0bYIOSGmTv4paBOuZL0H75Jd/EA099KtEVdvs3sJNl6MizLCUnKQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-versions/-/typedoc-plugin-versions-0.2.1.tgz",
+      "integrity": "sha512-JWNziM5ATtXa9jSnul1a8mlEfoAZX5NGekCz1rVJ/2RyAAfeHYM7LVQmTzmHPdXMfoJH56oJMgINLJ2Ri2SARQ==",
       "dev": true,
       "requires": {
         "fs-extra": "^10.1.0",
         "semver": "^7.3.7"
+      }
+    },
+    "typedoc-plugin-versions-cli": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-versions-cli/-/typedoc-plugin-versions-cli-0.1.5.tgz",
+      "integrity": "sha512-vKmqxljKX4FRICO2Ana1j+gSC9Y+LyVeE0ThMP3j1wtSXnZhP5t53OA65n+nL0JXDdiImZfU0EbL1pTM3a+/uQ==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.4",
+        "cli-diff": "^1.0.0",
+        "prompts": "^2.4.2",
+        "semver": "^7.3.7",
+        "yargs": "^17.5.1"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "build": "tsc",
     "prebuild": "npm run format",
     "docs": "typedoc",
-    "predocs": "npm run format"
+    "postdocs": "npm run docs:purge",
+    "docs:purge": "tpv purge -y --patch 3",
+    "postdocs:purge": "npm run docs:sync",
+    "docs:sync": "tpv sync -y --symlinks"
   },
   "dependencies": {
     "@msgpack/msgpack": "^2.7.2",
@@ -56,8 +59,9 @@
     "prettier": "2.7.1",
     "ts-jest": "^28.0.8",
     "typed-emitter": "^2.1.0",
-    "typedoc": "^0.23.14",
-    "typedoc-plugin-versions": "^0.2.0",
+    "typedoc": "^0.23.15",
+    "typedoc-plugin-versions": "^0.2.1",
+    "typedoc-plugin-versions-cli": "^0.1.5",
     "typescript": "^4.8.0"
   },
   "files": [


### PR DESCRIPTION
## Changes in this pull request
- Adds `typedoc-plugin-versions-cli` dev dependency, configured to automatically purge stale docs and trim excess docs to latest 3 patch versions whenever docs are generated